### PR TITLE
Fix: ISY-969: SonarCloud integration for feature workflow of isy-datetime

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -2,6 +2,9 @@
 name: Feature Workflow
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
Set event trigger push on branch develop as Feature Workflow (with the SonarCloud Scan) needs to be triggered when a pull request is merged.