### PR TITLE
chore: IFS-3767: added workflow dispatch for manual trigger

### DIFF
--- a/.github/workflows/maven_dependency_scan.yml
+++ b/.github/workflows/maven_dependency_scan.yml
@@ -6,6 +6,7 @@ on:
       - release/**
     paths:
       - 'pom.xml'
+  workflow_dispatch:
 
 jobs:
   DependencyScan:


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a `workflow_dispatch` event to the Maven dependency scan GitHub Actions workflow, allowing it to be triggered manually.
- This enhancement facilitates more flexible and on-demand execution of the dependency scan process.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maven_dependency_scan.yml</strong><dd><code>Add manual trigger capability to Maven dependency scan workflow</code></dd></summary>
<hr>

.github/workflows/maven_dependency_scan.yml

<li>Added <code>workflow_dispatch</code> to enable manual triggering of the workflow.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isy-datetime/pull/59/files#diff-7ca9a6c40325715da9366953b85546c8eb60c7474bb8bda99903e66e79eb9447">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

