### PR TITLE
IFS-3719: Skipping DeployGitHubPackages job until artifactId problem is resolved

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -27,19 +27,19 @@ jobs:
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  DeployGitHubPackages:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/'))
-    needs: [MavenBuild, Version]
-    uses: IsyFact/isy-github-actions-templates/.github/workflows/maven_deploy_template.yml@v1.5.0
-    with:
-      version: ${{ needs.Version.outputs.next-version }}
-      jdk-version: 21
-      maven-opts: '-DaltDeploymentRepository=github::default::https://maven.pkg.github.com/IsyFact/isy-datetime'
-      deploy-server-id: github
-      sbom: ${{ startsWith(github.ref, 'refs/heads/release/') }}
-      sign: true
-    secrets:
-      GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      DEPLOY_SERVER_USER_NAME: ${{ github.actor }}
-      DEPLOY_SERVER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#  DeployGitHubPackages:
+#    if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/'))
+#    needs: [MavenBuild, Version]
+#    uses: IsyFact/isy-github-actions-templates/.github/workflows/maven_deploy_template.yml@v1.5.0
+#    with:
+#      version: ${{ needs.Version.outputs.next-version }}
+#      jdk-version: 21
+#      maven-opts: '-DaltDeploymentRepository=github::default::https://maven.pkg.github.com/IsyFact/isy-datetime'
+#      deploy-server-id: github
+#      sbom: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+#      sign: true
+#    secrets:
+#      GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+#      GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+#      DEPLOY_SERVER_USER_NAME: ${{ github.actor }}
+#      DEPLOY_SERVER_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **PR Type**
bug_fix, configuration changes


___

### **Description**
- The `DeployGitHubPackages` job in the GitHub Actions workflow has been commented out to skip its execution.
- This change is a temporary measure due to an unresolved issue with the `artifactId`.
- The workflow configuration has been adjusted to prevent deployment until the problem is resolved.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maven_build.yml</strong><dd><code>Comment out DeployGitHubPackages job in GitHub Actions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven_build.yml

<li>Commented out the <code>DeployGitHubPackages</code> job.<br> <li> Skipped deployment step due to an unresolved <code>artifactId</code> issue.


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isy-datetime/pull/67/files#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764">+16/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information