### PR TITLE
fix: IFS-0000: fixed ORT template reference

### DIFF
--- a/.github/workflows/maven_dependency_scan.yml
+++ b/.github/workflows/maven_dependency_scan.yml
@@ -20,7 +20,7 @@ jobs:
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
-  ORT:
-    uses: IsyFact/isy-github-actions-templates/.github/workflows/oss_review_toolkit_template.yml@v1.5.0
-    secrets:
-      ANTORA_TRIGGER_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+#  ORT:
+#    uses: IsyFact/isy-github-actions-templates/.github/workflows/oss_review_toolkit_template.yml@v1.5.0
+#    secrets:
+#      ANTORA_TRIGGER_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}

--- a/.github/workflows/maven_dependency_scan.yml
+++ b/.github/workflows/maven_dependency_scan.yml
@@ -21,6 +21,6 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
   ORT:
-    uses: IsyFact/isy-github-actions-templates/.github/workflows/oss_review_toolkit_template.yml@1.5.0
+    uses: IsyFact/isy-github-actions-templates/.github/workflows/oss_review_toolkit_template.yml@v1.5.0
     secrets:
       ANTORA_TRIGGER_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}


### PR DESCRIPTION
### **PR Type**
bug_fix, configuration changes


___

### **Description**
- Fixed the ORT template version reference in the GitHub Actions workflow file to ensure the correct version is used.
- Updated the version from `1.5.0` to `v1.5.0` for consistency and correctness.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maven_dependency_scan.yml</strong><dd><code>Fix ORT template version reference in GitHub Actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven_dependency_scan.yml

<li>Fixed the version reference for the ORT template.<br> <li> Changed from version <code>1.5.0</code> to <code>v1.5.0</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isy-datetime/pull/75/files#diff-7ca9a6c40325715da9366953b85546c8eb60c7474bb8bda99903e66e79eb9447">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information